### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/kdl_parser/src/kdl_parser.cpp
+++ b/kdl_parser/src/kdl_parser.cpp
@@ -86,7 +86,8 @@ KDL::Joint toKdl(urdf::JointSharedPtr jnt)
         return KDL::Joint(jnt->name, F_parent_jnt.p, F_parent_jnt.M * axis, KDL::Joint::TransAxis);
       }
     default: {
-        fprintf(stderr, "Converting unknown joint type of joint '%s' into a fixed joint\n",
+        fprintf(
+          stderr, "Converting unknown joint type of joint '%s' into a fixed joint\n",
           jnt->name.c_str());
         return KDL::Joint(jnt->name, KDL::Joint::None);
       }
@@ -206,7 +207,8 @@ bool treeFromUrdfModel(const urdf::ModelInterface & robot_model, KDL::Tree & tre
 
   // warn if root link has inertia. KDL does not support this
   if (robot_model.getRoot()->inertial) {
-    fprintf(stderr, "The root link %s has an inertia specified in the URDF, but KDL does not "
+    fprintf(
+      stderr, "The root link %s has an inertia specified in the URDF, but KDL does not "
       "support a root link with an inertia.  As a workaround, you can add an extra "
       "dummy link to your URDF.\n", robot_model.getRoot()->name.c_str());
   }

--- a/kdl_parser/test/test_kdl_parser.cpp
+++ b/kdl_parser/test/test_kdl_parser.cpp
@@ -73,7 +73,8 @@ TEST_F(TestParser, test) {
   ASSERT_EQ((unsigned int)1, my_tree.getRootSegment()->second.children.size());
   ASSERT_TRUE(my_tree.getSegment("base_link")->second.parent == my_tree.getRootSegment());
   ASSERT_EQ(10.0, my_tree.getSegment("base_link")->second.segment.getInertia().getMass());
-  ASSERT_NEAR(1.000, my_tree.getSegment(
+  ASSERT_NEAR(
+    1.000, my_tree.getSegment(
       "base_link")->second.segment.getInertia().getRotationalInertia().data[0], 0.001);
   SUCCEED();
 }


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.